### PR TITLE
Fix brokenness in Dupe when put requests return HTTP 204

### DIFF
--- a/lib/dupe/active_resource_extensions.rb
+++ b/lib/dupe/active_resource_extensions.rb
@@ -57,8 +57,10 @@ module ActiveResource #:nodoc:
         
       # if the request threw an exception
       rescue
-        resource_hash = Hash.from_xml(body)
-        resource_hash = resource_hash[resource_hash.keys.first]
+        unless body.blank?
+          resource_hash = Hash.from_xml(body)
+          resource_hash = resource_hash[resource_hash.keys.first]
+        end
         resource_hash = {} unless resource_hash.kind_of?(Hash)
         resource_hash.symbolize_keys!
 


### PR DESCRIPTION
This resolves an issue in Dupe wherein a blank body string (as you would expect from a HTTP 204 response to a PUT) is incorrectly deserialized. Tests have also been added.

Consider the following simple class:

```
class ExpirableBook < ActiveResource::Base
  self.site = 'http://example.com'
  def expire!; put(:expire); end
end
```

Calling `expire!` on this Duped resource will cause it to blow up:

```
  undefined method `keys' for nil:NilClass (NoMethodError)
  /home/johnf/.rvm/gems/ruby-1.8.7-p299@project-getaroom/bundler/gems/dupe-762f505cb2ad/lib/dupe/active_resource_extensions.rb:61:in `put'
  /home/johnf/.rvm/gems/ruby-1.8.7-p299@project-getaroom/gems/activeresource-3.0.0/lib/active_resource/custom_methods.rb:101:in `put'
```

This is because Dupe's override of the `put` method does not handle the case where the `body` portion of a response may be blank. This pull request fixes the issue and correctly handles this case.
