### PR TITLE
correctly handle POST request with blank body

### DIFF
--- a/lib/dupe/active_resource_extensions.rb
+++ b/lib/dupe/active_resource_extensions.rb
@@ -19,22 +19,24 @@ module ActiveResource #:nodoc:
         response = request(:get, path, build_request_headers(headers, :get, self.site.merge(path)))
         ActiveResource::HttpMock.delete_mock(:get, path)
       end
-      
+
       if ActiveResource::VERSION::MAJOR == 3 && ActiveResource::VERSION::MINOR >= 1
         response
       else
         format.decode(response.body)
       end
     end
-    
+
     def post(path, body = '', headers = {}) #:nodoc:
       begin
         response = request(:post, path, body.to_s, build_request_headers(headers, :post, self.site.merge(path)))
-        
+
       # if the request threw an exception
       rescue
-        resource_hash = Hash.from_xml(body)
-        resource_hash = resource_hash[resource_hash.keys.first]
+        unless body.blank?
+          resource_hash = Hash.from_xml(body)
+          resource_hash = resource_hash[resource_hash.keys.first]
+        end
         resource_hash = {} unless resource_hash.kind_of?(Hash)
         begin
           mocked_response, new_path = Dupe.network.request(:post, path, resource_hash)
@@ -55,11 +57,11 @@ module ActiveResource #:nodoc:
       end
       response
     end
-    
+
     def put(path, body = '', headers = {}) #:nodoc:
       begin
         response = request(:put, path, body.to_s, build_request_headers(headers, :put, self.site.merge(path)))
-        
+
       # if the request threw an exception
       rescue
         unless body.blank?
@@ -96,7 +98,7 @@ module ActiveResource #:nodoc:
         mock.delete(path, {}, nil, 200)
       end
       response = request(:delete, path, build_request_headers(headers, :delete, self.site.merge(path)))
-      
+
       ActiveResource::HttpMock.delete_mock(:delete, path)
       response
     end

--- a/spec/lib_specs/active_resource_extensions_spec.rb
+++ b/spec/lib_specs/active_resource_extensions_spec.rb
@@ -1,10 +1,10 @@
 require 'spec_helper'
 
-describe ActiveResource::Connection do 
+describe ActiveResource::Connection do
   before do
     Dupe.reset
   end
-  
+
   describe "#get" do
     before do
       @book = Dupe.create :book, :title => 'Rooby', :label => 'rooby'
@@ -13,12 +13,12 @@ describe ActiveResource::Connection do
         self.format = :xml
       end
     end
-    
-    it "should pass a request off to the Dupe network if the original request failed" do            
+
+    it "should pass a request off to the Dupe network if the original request failed" do
       Dupe.network.should_receive(:request).with(:get, '/books.xml').once.and_return(Dupe.find(:books).to_xml(:root => 'books'))
       books = Book.find(:all)
     end
-    
+
     it "should parse the xml and turn the result into active resource objects" do
       books = Book.find(:all)
       books.length.should == 1
@@ -27,7 +27,7 @@ describe ActiveResource::Connection do
       books.first.label.should == 'rooby'
     end
   end
-  
+
   describe "#post" do
     before do
       @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
@@ -36,31 +36,49 @@ describe ActiveResource::Connection do
         self.site = 'http://www.example.com'
       end
     end
-    
+
     it "should pass a request off to the Dupe network if the original request failed" do
       Dupe.network.should_receive(:request).with(:post, '/books.xml', Hash.from_xml(@book.to_xml(:root => 'book'))["book"] ).once
       book = Book.create({:label => 'rooby', :title => 'Rooby'})
     end
-    
+
     it "should parse the xml and turn the result into active resource objects" do
       book = Book.create({:label => 'rooby', :title => 'Rooby'})
       book.id.should == 2
       book.title.should == 'Rooby'
       book.label.should == 'rooby'
     end
-    
+
     it "should make ActiveResource throw an unprocessable entity exception if our Post mock throws a Dupe::UnprocessableEntity exception" do
       Post %r{/books\.xml} do |post_data|
         raise Dupe::UnprocessableEntity.new(:title => "must be present.") unless post_data["title"]
         Dupe.create :book, post_data
       end
-      
+
       b = Book.create
       b.new?.should be_true
       b.errors.should_not be_empty
       b = Book.create(:title => "hello")
       b.new?.should be_false
       b.errors.should be_empty
+    end
+
+    it "should handle request with blank body" do
+      class SubscribableBook < ActiveResource::Base
+        self.site = 'http://www.example.com'
+        self.format = :xml
+
+        def self.send_update_emails
+          post(:send_update_emails)
+        end
+      end
+
+      Post %r{/subscribable_books/send_update_emails\.xml} do |post_data|
+        Dupe.create :email, post_data
+      end
+
+      response = SubscribableBook.send_update_emails
+      response.code.should == 201
     end
   end
 
@@ -72,7 +90,7 @@ describe ActiveResource::Connection do
       end
       @ar_book = Book.find(1)
     end
-    
+
     it "should pass a request off to the Dupe network if the original request failed" do
       Dupe.network.should_receive(:request).with(:put, '/books/1.xml', Hash.from_xml(@book.merge(:title => "Rails!").to_xml(:root => 'book'))["book"].symbolize_keys!).once.and_return([nil, '/books/1.xml'])
       @ar_book.title = 'Rails!'
@@ -100,13 +118,13 @@ describe ActiveResource::Connection do
         @e = Dupe.create :expirable_book, :title => 'Impermanence', :state => 'active'
       end
 
-      it "should handle no-content responses" do 
+      it "should handle no-content responses" do
         response = ExpirableBook.find(@e.id).expire_copyrights!
         response.body.should be_blank
         response.code.to_s.should == "204"
       end
     end
-    
+
     it "should parse the xml and turn the result into active resource objects" do
       @book.title.should == "Rooby"
       @ar_book.title = "Rails!"
@@ -119,13 +137,13 @@ describe ActiveResource::Connection do
       @book.id.should == 1
       @book.label.should == 'rooby'
     end
-    
+
     it "should make ActiveResource throw an unprocessable entity exception if our Put mock throws a Dupe::UnprocessableEntity exception" do
       Put %r{/books/(\d+)\.xml} do |id, put_data|
         raise Dupe::UnprocessableEntity.new(:title => " must be present.") unless put_data[:title]
         Dupe.find(:book) {|b| b.id == id.to_i}.merge!(put_data)
       end
-      
+
       @ar_book.title = nil
       @ar_book.save.should == false
       @ar_book.errors[:base].should_not be_empty
@@ -147,12 +165,12 @@ describe ActiveResource::Connection do
       end
       @ar_book = Book.find(1)
     end
-    
+
     it "should pass a request off to the Dupe network if the original request failed" do
       Dupe.network.should_receive(:request).with(:delete, '/books/1.xml').once
       @ar_book.destroy
     end
-    
+
     it "trigger a Dupe.delete to delete the mocked resource from the duped database" do
       Dupe.find(:books).length.should == 1
       @ar_book.destroy


### PR DESCRIPTION
Dupe will throw a NoMethodError if received a POST request with blank body.  Although this is not very typical, I did encounter this problem in a real world application :(  I followed the way you handle blank PUT request to fix this.

BTW, my editor helps me remove all the tailing spaces, which looks a little weird in the github diff.
