### PR TITLE
Support for JSON-based services in Dupe

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,0 +1,2 @@
+--color
+--format documentation

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,25 @@
 PATH
   remote: .
   specs:
-    dupe (1.0.0)
+    dupe (1.0.1)
       activeresource (~> 3.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.0.9)
-      activesupport (= 3.0.9)
-      builder (~> 2.1.2)
-      i18n (~> 0.5.0)
-    activeresource (3.0.9)
-      activemodel (= 3.0.9)
-      activesupport (= 3.0.9)
-    activesupport (3.0.9)
-    builder (2.1.2)
+    activemodel (3.2.2)
+      activesupport (= 3.2.2)
+      builder (~> 3.0.0)
+    activeresource (3.2.2)
+      activemodel (= 3.2.2)
+      activesupport (= 3.2.2)
+    activesupport (3.2.2)
+      i18n (~> 0.6)
+      multi_json (~> 1.0)
+    builder (3.0.0)
     diff-lcs (1.1.2)
-    i18n (0.5.0)
+    i18n (0.6.0)
+    multi_json (1.1.0)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
       rspec-expectations (~> 2.6.0)

--- a/lib/dupe/dupe.rb
+++ b/lib/dupe/dupe.rb
@@ -11,7 +11,10 @@ class Dupe
     # set this to "true" if you want Dupe to spit out mocked requests
     # after each of your cucumber scenario's run
     attr_accessor :debug
-    
+
+    # Get the format to use (default is ActiveResource::Base.format)
+    attr_accessor :format
+
     # Suppose we're creating a 'book' resource. Perhaps our app assumes every book has a title, so let's define a book resource
     # that specifies just that:
     # 
@@ -171,27 +174,27 @@ class Dupe
         mocks = %{
           network.define_service_mock(
             :get, 
-            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}\\.xml$}, 
+            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}\\.(?:xml|json)$}, 
             proc { Dupe.find(:#{model_name.to_s.pluralize}) }
           )
           network.define_service_mock(
             :get, 
-            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}/(\\d+)\\.xml$}, 
+            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}/(\\d+)\\.(?:xml|json)$}, 
             proc {|id| Dupe.find(:#{model_name}) {|resource| resource.id == id.to_i}}
           )
           network.define_service_mock(
             :post, 
-            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}\\.xml$}, 
+            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}\\.(?:xml|json)$}, 
             proc { |post_body| Dupe.create(:#{model_name.to_s}, post_body) }
           )
           network.define_service_mock(
             :put,
-            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}/(\\d+)\\.xml$}, 
+            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}/(\\d+)\\.(?:xml|json)$}, 
             proc { |id, put_data| Dupe.find(:#{model_name.to_s}) {|resource| resource.id == id.to_i}.merge!(put_data) }
           )
           network.define_service_mock(
             :delete,
-            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}/(\\d+)\\.xml$}, 
+            %r{^#{model_name.to_s.titleize.constantize.prefix rescue '/'}#{model_name.to_s.pluralize}/(\\d+)\\.(?:xml|json)$}, 
             proc { |id| Dupe.delete(:#{model_name.to_s}) {|resource| resource.id == id.to_i} }
           )
         }
@@ -460,7 +463,10 @@ class Dupe
       @debug ||= false
     end
     
-    
+    # Get the current format, defaulting to ActiveResource's configured formatter
+    def format
+      @format ||= ActiveResource::Base.format
+    end   
     
     private
     def build_conditions(conditions)

--- a/lib/dupe/hash_pruner.rb
+++ b/lib/dupe/hash_pruner.rb
@@ -31,7 +31,11 @@ class HashPruner
 end
 
 class Hash 
-  def to_xml_safe(options={})
-    HashPruner.prune(self).to_xml(options)  
+  def make_safe
+    HashPruner.prune(self)
+  end
+
+  def self.from_json(s)
+    ActiveSupport::JSON.decode(s)
   end
 end

--- a/spec/lib_specs/active_resource_extensions_spec.rb
+++ b/spec/lib_specs/active_resource_extensions_spec.rb
@@ -1,189 +1,376 @@
 require 'spec_helper'
 
 describe ActiveResource::Connection do
-  before do
-    Dupe.reset
-  end
-
-  describe "#get" do
+  describe "using xml " do
     before do
-      @book = Dupe.create :book, :title => 'Rooby', :label => 'rooby'
-      class Book < ActiveResource::Base
-        self.site   = 'http://www.example.com'
-        self.format = :xml
-      end
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::XmlFormat
     end
 
-    it "should pass a request off to the Dupe network if the original request failed" do
-      Dupe.network.should_receive(:request).with(:get, '/books.xml').once.and_return(Dupe.find(:books).to_xml(:root => 'books'))
-      books = Book.find(:all)
-    end
-
-    it "should parse the xml and turn the result into active resource objects" do
-      books = Book.find(:all)
-      books.length.should == 1
-      books.first.id.should == 1
-      books.first.title.should == 'Rooby'
-      books.first.label.should == 'rooby'
-    end
-  end
-
-  describe "#post" do
-    before do
-      @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
-      @book.delete(:id)
-      class Book < ActiveResource::Base
-        self.site = 'http://www.example.com'
-      end
-    end
-
-    it "should pass a request off to the Dupe network if the original request failed" do
-      Dupe.network.should_receive(:request).with(:post, '/books.xml', Hash.from_xml(@book.to_xml(:root => 'book'))["book"] ).once
-      book = Book.create({:label => 'rooby', :title => 'Rooby'})
-    end
-
-    it "should parse the xml and turn the result into active resource objects" do
-      book = Book.create({:label => 'rooby', :title => 'Rooby'})
-      book.id.should == 2
-      book.title.should == 'Rooby'
-      book.label.should == 'rooby'
-    end
-
-    it "should make ActiveResource throw an unprocessable entity exception if our Post mock throws a Dupe::UnprocessableEntity exception" do
-      Post %r{/books\.xml} do |post_data|
-        raise Dupe::UnprocessableEntity.new(:title => "must be present.") unless post_data["title"]
-        Dupe.create :book, post_data
-      end
-
-      b = Book.create
-      b.new?.should be_true
-      b.errors.should_not be_empty
-      b = Book.create(:title => "hello")
-      b.new?.should be_false
-      b.errors.should be_empty
-    end
-
-    it "should handle request with blank body" do
-      class SubscribableBook < ActiveResource::Base
-        self.site = 'http://www.example.com'
-        self.format = :xml
-
-        def self.send_update_emails
-          post(:send_update_emails)
+    describe "#get" do
+      before do
+        @book = Dupe.create :book, :title => 'Rooby', :label => 'rooby'
+        class Book < ActiveResource::Base
+          self.site   = 'http://www.example.com'
+          self.format = :xml
         end
       end
 
-      Post %r{/subscribable_books/send_update_emails\.xml} do |post_data|
-        Dupe.create :email, post_data
+      it "should pass a request off to the Dupe network if the original request failed" do
+        Dupe.network.should_receive(:request).with(:get, '/books.xml').once.and_return(Dupe.find(:books).to_xml(:root => 'books'))
+        books = Book.find(:all)
       end
 
-      response = SubscribableBook.send_update_emails
-      response.code.should == 201
-    end
-  end
-
-  describe "#put" do
-    before do
-      @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
-      class Book < ActiveResource::Base
-        self.site = 'http://www.example.com'
+      it "should parse the xml and turn the result into active resource objects" do
+        books = Book.find(:all)
+        books.length.should == 1
+        books.first.id.should == 1
+        books.first.title.should == 'Rooby'
+        books.first.label.should == 'rooby'
       end
-      @ar_book = Book.find(1)
     end
 
-    it "should pass a request off to the Dupe network if the original request failed" do
-      Dupe.network.should_receive(:request).with(:put, '/books/1.xml', Hash.from_xml(@book.merge(:title => "Rails!").to_xml(:root => 'book'))["book"].symbolize_keys!).once.and_return([nil, '/books/1.xml'])
-      @ar_book.title = 'Rails!'
-      @ar_book.save
-    end
+    describe "#post" do
+      before do
+        @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
+        @book.delete(:id)
+        class Book < ActiveResource::Base
+          self.site = 'http://www.example.com'
+        end
+      end
 
-    context "put methods that return HTTP 204" do
-      before(:each) do
-        class ExpirableBook < ActiveResource::Base
-          self.site   = 'http://www.example.com'
+      it "should pass a request off to the Dupe network if the original request failed" do
+        Dupe.network.should_receive(:request).with(:post, '/books.xml', Hash.from_xml(@book.to_xml(:root => 'book'))["book"] ).once
+        book = Book.create({:label => 'rooby', :title => 'Rooby'})
+      end
+
+      it "should parse the xml and turn the result into active resource objects" do
+        book = Book.create({:label => 'rooby', :title => 'Rooby'})
+        book.id.should == 2
+        book.title.should == 'Rooby'
+        book.label.should == 'rooby'
+      end
+
+      it "should make ActiveResource throw an unprocessable entity exception if our Post mock throws a Dupe::UnprocessableEntity exception" do
+        Post %r{/books\.xml} do |post_data|
+          raise Dupe::UnprocessableEntity.new(:title => "must be present.") unless post_data["title"]
+          Dupe.create :book, post_data
+        end
+
+        b = Book.create
+        b.new?.should be_true
+        b.errors.should_not be_empty
+        b = Book.create(:title => "hello")
+        b.new?.should be_false
+        b.errors.should be_empty
+      end
+
+      it "should handle request with blank body" do
+        class SubscribableBook < ActiveResource::Base
+          self.site = 'http://www.example.com'
           self.format = :xml
-          attr_accessor :state
 
-          def expire_copyrights!
-            put(:expire)
+          def self.send_update_emails
+            post(:send_update_emails)
           end
         end
 
-        Put %r{/expirable_books/(\d)+/expire.xml} do |id, body|
-          Dupe.find(:expirable_book) { |eb| eb.id == id.to_i }.tap { |book|
-            book.state = 'expired'
-          }
+        Post %r{/subscribable_books/send_update_emails\.xml} do |post_data|
+          Dupe.create :email, post_data
         end
 
-        @e = Dupe.create :expirable_book, :title => 'Impermanence', :state => 'active'
-      end
-
-      it "should handle no-content responses" do
-        response = ExpirableBook.find(@e.id).expire_copyrights!
-        response.body.should be_blank
-        response.code.to_s.should == "204"
+        response = SubscribableBook.send_update_emails
+        response.code.should == 201
       end
     end
 
-    it "should parse the xml and turn the result into active resource objects" do
-      @book.title.should == "Rooby"
-      @ar_book.title = "Rails!"
-      @ar_book.save
-      @ar_book.new?.should == false
-      @ar_book.valid?.should == true
-      @ar_book.id.should == 1
-      @ar_book.label.should == "rooby"
-      @book.title.should == "Rails!"
-      @book.id.should == 1
-      @book.label.should == 'rooby'
-    end
-
-    it "should make ActiveResource throw an unprocessable entity exception if our Put mock throws a Dupe::UnprocessableEntity exception" do
-      Put %r{/books/(\d+)\.xml} do |id, put_data|
-        raise Dupe::UnprocessableEntity.new(:title => " must be present.") unless put_data[:title]
-        Dupe.find(:book) {|b| b.id == id.to_i}.merge!(put_data)
+    describe "#put" do
+      before do
+        @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
+        class Book < ActiveResource::Base
+          self.site = 'http://www.example.com'
+        end
+        @ar_book = Book.find(1)
       end
 
-      @ar_book.title = nil
-      @ar_book.save.should == false
-      @ar_book.errors[:base].should_not be_empty
+      it "should pass a request off to the Dupe network if the original request failed" do
+        Dupe.network.should_receive(:request).with(:put, '/books/1.xml', Hash.from_xml(@book.merge(:title => "Rails!").to_xml(:root => 'book'))["book"].symbolize_keys!).once.and_return([nil, '/books/1.xml'])
+        @ar_book.title = 'Rails!'
+        @ar_book.save
+      end
 
-      @ar_book.title = "Rails!"
-      @ar_book.save.should == true
-      # the following line should be true, were it not for a bug in active_resource 2.3.3 - 2.3.5
-      # i reported the bug here: https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/4169-activeresourcebasesave-put-doesnt-clear-out-errors
-      # @ar_book.errors.should be_empty
+      context "put methods that return HTTP 204" do
+        before(:each) do
+          class ExpirableBook < ActiveResource::Base
+            self.site   = 'http://www.example.com'
+            self.format = :xml
+            attr_accessor :state
+
+            def expire_copyrights!
+              put(:expire)
+            end
+          end
+
+          Put %r{/expirable_books/(\d)+/expire.xml} do |id, body|
+            Dupe.find(:expirable_book) { |eb| eb.id == id.to_i }.tap { |book|
+              book.state = 'expired'
+            }
+          end
+
+          @e = Dupe.create :expirable_book, :title => 'Impermanence', :state => 'active'
+        end
+
+        it "should handle no-content responses" do
+          response = ExpirableBook.find(@e.id).expire_copyrights!
+          response.body.should be_blank
+          response.code.to_s.should == "204"
+        end
+      end
+
+      it "should parse the xml and turn the result into active resource objects" do
+        @book.title.should == "Rooby"
+        @ar_book.title = "Rails!"
+        @ar_book.save
+        @ar_book.new?.should == false
+        @ar_book.valid?.should == true
+        @ar_book.id.should == 1
+        @ar_book.label.should == "rooby"
+        @book.title.should == "Rails!"
+        @book.id.should == 1
+        @book.label.should == 'rooby'
+      end
+
+      it "should make ActiveResource throw an unprocessable entity exception if our Put mock throws a Dupe::UnprocessableEntity exception" do
+        Put %r{/books/(\d+)\.xml} do |id, put_data|
+          raise Dupe::UnprocessableEntity.new(:title => " must be present.") unless put_data[:title]
+          Dupe.find(:book) {|b| b.id == id.to_i}.merge!(put_data)
+        end
+
+        @ar_book.title = nil
+        @ar_book.save.should == false
+        @ar_book.errors[:base].should_not be_empty
+
+        @ar_book.title = "Rails!"
+        @ar_book.save.should == true
+        # the following line should be true, were it not for a bug in active_resource 2.3.3 - 2.3.5
+        # i reported the bug here: https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/4169-activeresourcebasesave-put-doesnt-clear-out-errors
+        # @ar_book.errors.should be_empty
+      end
+    end
+
+    describe "#delete" do
+      before do
+        @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
+        class Book < ActiveResource::Base
+          self.site   = 'http://www.example.com'
+          self.format = :xml
+        end
+        @ar_book = Book.find(1)
+      end
+
+      it "should pass a request off to the Dupe network if the original request failed" do
+        Dupe.network.should_receive(:request).with(:delete, '/books/1.xml').once
+        @ar_book.destroy
+      end
+
+      it "trigger a Dupe.delete to delete the mocked resource from the duped database" do
+        Dupe.find(:books).length.should == 1
+        @ar_book.destroy
+        Dupe.find(:books).length.should == 0
+      end
+
+      it "should allow you to override the default DELETE intercept mock" do
+        Delete %r{/books/(\d+)\.xml} do |id|
+          raise StandardError, "Testing Delete override"
+        end
+
+        proc {@ar_book.destroy}.should raise_error(StandardError, "Testing Delete override")
+      end
     end
   end
 
-  describe "#delete" do
+  describe "using json " do
     before do
-      @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
-      class Book < ActiveResource::Base
-        self.site   = 'http://www.example.com'
-        self.format = :xml
-      end
-      @ar_book = Book.find(1)
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::JsonFormat
     end
 
-    it "should pass a request off to the Dupe network if the original request failed" do
-      Dupe.network.should_receive(:request).with(:delete, '/books/1.xml').once
-      @ar_book.destroy
-    end
-
-    it "trigger a Dupe.delete to delete the mocked resource from the duped database" do
-      Dupe.find(:books).length.should == 1
-      @ar_book.destroy
-      Dupe.find(:books).length.should == 0
-    end
-
-    it "should allow you to override the default DELETE intercept mock" do
-      Delete %r{/books/(\d+)\.xml} do |id|
-        raise StandardError, "Testing Delete override"
+    describe "#get" do
+      before do
+        @book = Dupe.create :book, :title => 'Rooby', :label => 'rooby'
+        class Book < ActiveResource::Base
+          self.site   = 'http://www.example.com'
+          self.format = :json
+        end
       end
 
-      proc {@ar_book.destroy}.should raise_error(StandardError, "Testing Delete override")
+      it "should pass a request off to the Dupe network if the original request failed" do
+        Dupe.network.should_receive(:request).with(:get, '/books.json').once.and_return(Dupe.find(:books).to_json(:root => 'books'))
+        books = Book.find(:all)
+      end
+
+      it "should parse the json and turn the result into active resource objects" do
+        books = Book.find(:all)
+        books.length.should == 1
+        books.first.id.should == 1
+        books.first.title.should == 'Rooby'
+        books.first.label.should == 'rooby'
+      end
+    end
+
+    describe "#post" do
+      before do
+        @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
+        @book.delete(:id)
+        class Book < ActiveResource::Base
+          self.site = 'http://www.example.com'
+        end
+      end
+
+      it "should pass a request off to the Dupe network if the original request failed" do
+        Dupe.network.should_receive(:request).with(:post, '/books.json', Hash.from_json(@book.to_json(:root => 'book')) ).once
+        book = Book.create({:label => 'rooby', :title => 'Rooby'})
+      end
+
+      it "should parse the json and turn the result into active resource objects" do
+        book = Book.create({:label => 'rooby', :title => 'Rooby'})
+        book.id.should == 2
+        book.title.should == 'Rooby'
+        book.label.should == 'rooby'
+      end
+
+      it "should make ActiveResource throw an unprocessable entity exception if our Post mock throws a Dupe::UnprocessableEntity exception" do
+        Post %r{/books\.json} do |post_data|
+          raise Dupe::UnprocessableEntity.new(:title => "must be present.") unless post_data["title"]
+          Dupe.create :book, post_data
+        end
+
+        b = Book.create
+        b.new?.should be_true
+        b.should_not be_empty
+      end
+
+      it "should handle request with blank body" do
+        class SubscribableBook < ActiveResource::Base
+          self.site = 'http://www.example.com'
+          self.format = :json
+
+          def self.send_update_emails
+            post(:send_update_emails)
+          end
+        end
+
+        Post %r{/subscribable_books/send_update_emails\.json} do |post_data|
+          Dupe.create :email, post_data
+        end
+
+        response = SubscribableBook.send_update_emails
+        response.code.should == 201
+      end
+    end
+
+    describe "#put" do
+      before do
+        @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
+        class Book < ActiveResource::Base
+          self.site = 'http://www.example.com'
+        end
+        @ar_book = Book.find(1)
+      end
+
+      it "should pass a request off to the Dupe network if the original request failed" do
+        Dupe.network.should_receive(:request).with(:put, '/books/1.json', Hash.from_json(@book.merge(:title => "Rails!").to_json(:root => 'book')).symbolize_keys!).once.and_return([nil, '/books/1.json'])
+        @ar_book.title = 'Rails!'
+        @ar_book.save
+      end
+
+      context "put methods that return HTTP 204" do
+        before(:each) do
+          class ExpirableBook < ActiveResource::Base
+            self.site   = 'http://www.example.com'
+            self.format = :json
+            attr_accessor :state
+
+            def expire_copyrights!
+              put(:expire)
+            end
+          end
+
+          Put %r{/expirable_books/(\d)+/expire.json} do |id, body|
+            Dupe.find(:expirable_book) { |eb| eb.id == id.to_i }.tap { |book|
+              book.state = 'expired'
+            }
+          end
+
+          @e = Dupe.create :expirable_book, :title => 'Impermanence', :state => 'active'
+        end
+
+        it "should handle no-content responses" do
+          response = ExpirableBook.find(@e.id).expire_copyrights!
+          response.body.should be_blank
+          response.code.to_s.should == "204"
+        end
+      end
+
+      it "should parse the json and turn the result into active resource objects" do
+        @book.title.should == "Rooby"
+        @ar_book.title = "Rails!"
+        @ar_book.save
+        @ar_book.new?.should == false
+        @ar_book.valid?.should == true
+        @ar_book.id.should == 1
+        @ar_book.label.should == "rooby"
+        @book.title.should == "Rails!"
+        @book.id.should == 1
+        @book.label.should == 'rooby'
+      end
+
+      it "should make ActiveResource throw an unprocessable entity exception if our Put mock throws a Dupe::UnprocessableEntity exception" do
+        Put %r{/books/(\d+)\.json} do |id, put_data|
+          raise Dupe::UnprocessableEntity.new(:title => " must be present.") unless put_data[:title]
+          Dupe.find(:book) {|b| b.id == id.to_i}.merge!(put_data)
+        end
+
+        @ar_book.title = nil
+        @ar_book.save.should == false
+        @ar_book.should_not be_empty
+
+        @ar_book.title = "Rails!"
+        @ar_book.save.should == true
+        # the following line should be true, were it not for a bug in active_resource 2.3.3 - 2.3.5
+        # i reported the bug here: https://rails.lighthouseapp.com/projects/8994-ruby-on-rails/tickets/4169-activeresourcebasesave-put-doesnt-clear-out-errors
+        # @ar_book.errors.should be_empty
+      end
+    end
+
+    describe "#delete" do
+      before do
+        @book = Dupe.create :book, :label => 'rooby', :title => 'Rooby'
+        class Book < ActiveResource::Base
+          self.site   = 'http://www.example.com'
+          self.format = :json
+        end
+        @ar_book = Book.find(1)
+      end
+
+      it "should pass a request off to the Dupe network if the original request failed" do
+        Dupe.network.should_receive(:request).with(:delete, '/books/1.json').once
+        @ar_book.destroy
+      end
+
+      it "trigger a Dupe.delete to delete the mocked resource from the duped database" do
+        Dupe.find(:books).length.should == 1
+        @ar_book.destroy
+        Dupe.find(:books).length.should == 0
+      end
+
+      it "should allow you to override the default DELETE intercept mock" do
+        Delete %r{/books/(\d+)\.json} do |id|
+          raise StandardError, "Testing Delete override"
+        end
+
+        proc {@ar_book.destroy}.should raise_error(StandardError, "Testing Delete override")
+      end
     end
   end
-
 end

--- a/spec/lib_specs/dupe_spec.rb
+++ b/spec/lib_specs/dupe_spec.rb
@@ -4,7 +4,7 @@ describe Dupe do
   before do
     Dupe.reset
   end
-  
+
   describe "#sequences" do 
     it "should be empty on initialization" do
       Dupe.sequences.should == {}
@@ -44,7 +44,7 @@ describe Dupe do
       Dupe.next(:email).should == "email-2@address.com"
     end
   end
-  
+
   describe "reset" do
     it "should call reset_models, reset_database, and reset_network" do
       Dupe.should_receive(:reset_models).once
@@ -66,7 +66,7 @@ describe Dupe do
       Dupe.sequences.should == {}
     end
   end
-  
+
   describe "reset_models" do
     it "should reset @models to an empty hash" do
       Dupe.models.length.should == 0
@@ -79,7 +79,7 @@ describe Dupe do
       Dupe.models.should == {}
     end
   end
-  
+
   describe "reset_database" do
     it "should clear out the database" do
       Dupe.define :book
@@ -89,7 +89,7 @@ describe Dupe do
       Dupe.database.tables.should be_empty
     end    
   end
-  
+
   describe "reset_network" do
     it "should clear out the network" do
       Dupe.create :book
@@ -99,9 +99,285 @@ describe Dupe do
       Dupe.network.mocks.values.inject(false) {|b,v| b || !v.empty?}.should == false
     end    
   end
-  
+
+  describe "create" do
+    it "should require a model name parameter" do
+      proc {Dupe.create}.should raise_error(ArgumentError)
+      proc {Dupe.create :book}.should_not raise_error(ArgumentError)
+    end
+
+    it "should create a model if one doesn't already exist" do
+      Dupe.models.should be_empty
+      Dupe.create :book
+      Dupe.models.should_not be_empty
+      Dupe.models[:book].should_not be_nil
+      Dupe.models[:book].name.should == :book
+    end
+
+    it "should be smart enough to singularize the model name before lookup/create" do
+      Dupe.define :book
+      Dupe.models.should_not be_empty
+      Dupe.models.length.should == 1
+      Dupe.models[:book].should_not be_nil
+      Dupe.create :books
+      Dupe.models.length.should == 1
+      Dupe.models[:books].should be_nil
+      Dupe.models[:book].should_not be_nil
+      Dupe.create :authors
+      Dupe.models.length.should == 2
+      Dupe.models[:author].should_not be_nil
+      Dupe.models[:author].name.should == :author
+      Dupe.models[:authors].should be_nil
+    end
+
+    it "should create (and return) a database record if passed a single hash" do
+      Dupe.define :book
+      Dupe.database.tables[:book].should be_empty
+      @book = Dupe.create :book, :title => 'test'
+      Dupe.database.tables[:book].should_not be_empty
+      Dupe.database.tables[:book].length.should == 1
+      Dupe.database.tables[:book].first.should == @book
+    end
+
+    it "should create several records if passed an array of hashes (and return an array of the records created)" do
+      Dupe.define :book
+      Dupe.database.tables[:book].should be_empty
+      @books = Dupe.create :books, [{:title => 'Book 1'}, {:title => 'Book 2'}]
+      Dupe.database.tables[:book].should_not be_empty
+      Dupe.database.tables[:book].length.should == 2
+      Dupe.database.tables[:book].first.should == @books.first
+      Dupe.database.tables[:book].last.should == @books.last      
+    end
+
+    it "should symbolize hash keys to keep from duplicating column names" do 
+      b = Dupe.create :book, 'title' => 'War And Peace', :title => 'War And Peace'
+      b.title.should == 'War And Peace'
+      b[:title].should == 'War And Peace'
+      b['title'].should == nil
+
+      bs = Dupe.create :books, [{:test => 2, 'test' => 2}, {:test => 4, 'test' => 4}]
+      bs.first.test.should == 2
+      bs.first[:test].should == 2
+      bs.first['test'].should == nil
+      bs.last.test.should == 4
+      bs.last[:test].should == 4
+      bs.last['test'].should == nil
+    end
+  end
+
+  describe "create resources with unique attributes" do
+    before do
+      Dupe.define :book do |book|
+        book.uniquify :title, :author, :genre
+      end
+    end
+
+    it "should uniquify the appropriate columns if they don't already have values" do
+      b = Dupe.create :book
+      b.title.should == "book 1 title"
+      b.author.should == "book 1 author"
+      b.genre.should == "book 1 genre"
+
+      b = Dupe.create :book, :title => 'Rooby Rocks', :isbn => 1
+      b.title.should == 'Rooby Rocks'
+      b.author.should == "book 2 author"
+      b.genre.should == "book 2 genre"
+      b.isbn.should == 1
+    end
+  end
+
+  describe "create resources that have an after_create callback" do
+    before do
+      Dupe.define :book do |book|
+        book.uniquify :title, :author, :genre
+        
+        book.after_create do |b|
+          b.label = b.title.downcase.gsub(/\ +/, '-') unless b.label
+        end
+      end
+    end
+
+    it "should create a label based on the title if a label is passed in during the create call" do
+      b = Dupe.create :book, :title => 'Testing Testing'
+      b.label.should == 'testing-testing'
+      b = Dupe.create :book, :title => 'Testing Testing', :label => 'testbook'
+      b.label.should == 'testbook'
+    end
+  end
+
+  describe "find" do
+    before do
+      Dupe.define :book
+      @book = Dupe.create :book
+    end
+
+    it "should require a model name parameter" do
+      proc { Dupe.find }.should raise_error(ArgumentError)
+    end
+
+    it "should require the model to exist" do
+      proc { Dupe.find :unknown_models }.should raise_error(Dupe::Database::TableDoesNotExistError)
+    end
+
+    it "should return an array if you ask for a plural model (e.g., Dupe.find :books)" do
+      result = Dupe.find :books
+      result.should be_kind_of(Array)
+      result.should_not be_empty
+      result.length.should == 1
+      result.first.should == @book
+    end
+
+    it "should return a single record (or nil) if you ask for a singular model (e.g., Dupe.find :book)" do
+      result = Dupe.find :book
+      result.should be_kind_of(Dupe::Database::Record)
+      result.should == @book
+
+      result = Dupe.find(:book) {|b| false}
+      result.should be_nil
+    end
+  end
+
+  describe "debug" do
+    it "should default to false" do
+      Dupe.debug.should == false
+    end
+
+    it "should allow you to set it to true" do
+      Dupe.debug = true
+      Dupe.debug.should == true
+    end
+
+    it "should persist across a Dupe.reset" do
+      Dupe.debug = true
+      Dupe.debug.should == true
+      Dupe.reset
+      Dupe.debug.should == true
+    end
+  end
+
+  describe "stub" do
+    it ": when called with only a count and a model_name, it should generate that many blank (id-only) records" do
+      Dupe.database.tables[:author].should be_nil
+      authors = Dupe.stub 20, :authors
+      authors.length.should == 20
+      Dupe.database.tables[:author].length.should == 20
+      authors.collect(&:id).should == (1..20).to_a
+    end
+
+    it "should accept procs on stubs" do
+      Dupe.database.tables[:author].should be_nil
+      authors = 
+      Dupe.stub(
+        2, 
+        :authors, 
+        :like => {
+          :name => proc {|n| "Author #{n}"},
+          :bio => proc {|n| "Author #{n}'s bio"}
+        }
+        )
+      authors.first.name.should == "Author 1"
+      authors.first.bio.should == "Author 1's bio"
+      authors.last.name.should == "Author 2"
+      authors.last.bio.should == "Author 2's bio"
+      Dupe.database.tables[:author].length.should == 2
+    end
+
+    it "shouldn't care if the model_name is singular or plural" do
+      Dupe.database.tables.should be_empty
+      Dupe.stub 5, :author
+      Dupe.database.tables.should_not be_empty
+      Dupe.database.tables.length.should == 1
+      Dupe.database.tables[:author].length.should == 5
+      Dupe.stub 5, :authors
+      Dupe.database.tables[:author].length.should == 10
+      Dupe.database.tables.length.should == 1
+    end
+  end
+
+  describe "find_or_create" do
+    it "should require a model name" do
+      proc { Dupe.find_or_create }.should raise_error(ArgumentError)
+    end
+
+    it "should find a result if one exists" do
+      b = Dupe.create :book, :title => 'Rooby', :serial_number => 21345
+      found_book = Dupe.find_or_create :book, :title => 'Rooby', :serial_number => 21345
+      b.should === found_book
+
+      g = Dupe.create :genre, :name => 'Science Fiction', :label => 'sci-fi'
+      found_genre = Dupe.find_or_create :genre, :name => 'Science Fiction', :label => 'sci-fi'
+      g.should === found_genre
+    end
+
+    it "should create a result if one does not exist" do
+      Dupe.database.tables.should be_empty
+      author = Dupe.find_or_create :author, :name => 'Matt Parker', :age => 27, :label => 'matt-parker'
+      Dupe.database.tables.should_not be_empty
+      author.should === (Dupe.find(:author) {|a| a.label == 'matt-parker' && a.age == 27})
+    end
+
+    it "should return an array of results if passed a plural model name" do
+      books = Dupe.stub 20, :books, :like => { :title => proc {|n| "book ##{n} title"} }
+      bs = Dupe.find_or_create :books
+      books.should == bs
+    end
+
+    it "should create and return an array of results if passed a plural model name for which no matching records exist" do
+      Dupe.database.tables.should be_empty
+      books = Dupe.find_or_create :books, :author => 'test'
+      Dupe.database.tables.length.should == 1
+      books.should be_kind_of(Array)
+      books.should == Dupe.find(:books)
+    end
+
+  end
+
+  describe "creating resources should not change definitions (regression test)" do
+    before do
+      Dupe.define :book do |book|
+        book.authors []
+        book.genre do
+          Dupe.find_or_create :genre, :name => 'Sci-fi'
+        end
+      end
+    end
+
+    it "should not add a record to the definition when the default value is an array" do
+      b = Dupe.create :book
+      a = Dupe.create :author
+      b.authors << a
+      b.authors.include?(a).should be_true
+      b2 = Dupe.create :book
+      b2.authors.should be_empty
+    end
+
+    it "should not dupe the value returned by a lazy attribute" do
+      b = Dupe.create :book
+      b2 = Dupe.create :book
+      b.genre.should == b2.genre
+      b.genre.name = 'Science Fiction'
+      b2.genre.name.should == 'Science Fiction'
+    end
+  end
+
+  describe "##delete" do
+    it "should remove any resources that match the conditions provided in the block" do
+      Dupe.stub 10, :authors
+      Dupe.find(:authors).length.should == 10
+      Dupe.delete :author
+      Dupe.find(:authors).length.should == 9
+      Dupe.delete :authors
+      Dupe.find(:authors).length.should == 0
+      Dupe.create :author, :name => 'CS Lewis'
+      Dupe.create :author, :name => 'Robert Lewis Stevenson'
+      Dupe.create :author, :name => 'Frank Herbert'
+      Dupe.delete(:author) {|a| a.name.match /Lewis/}
+      Dupe.find(:authors).length.should == 1
+      Dupe.find(:authors).first.name.should == 'Frank Herbert'
+    end
+  end
+
   describe "define" do
-  
     # Dupe.define :model_name
     it "should accept a single symbol parameter" do
       proc {
@@ -166,357 +442,168 @@ describe Dupe do
       Dupe.database.tables[:book].should == []
     end
     
-    it "should add find(:all) and find(<id>) mocks to the network" do
-      Dupe.network.mocks[:get].should be_empty
-      Dupe.create :book
-      Dupe.network.mocks[:get].should_not be_empty
-      Dupe.network.mocks[:get].length.should == 2
-      
-      find_all_mock = Dupe.network.mocks[:get].first
-      find_all_mock.class.should == Dupe::Network::GetMock
-      find_all_mock.url_pattern.should == %r{^/books\.xml$}
-      find_all_mock.mocked_response('/books.xml').should == Dupe.find(:books).to_xml(:root => 'books')
-      
-      find_one_mock = Dupe.network.mocks[:get].last
-      find_one_mock.class.should == Dupe::Network::GetMock
-      find_one_mock.url_pattern.should == %r{^/books/(\d+)\.xml$}
-      find_one_mock.mocked_response('/books/1.xml').should == Dupe.find(:book).to_xml(:root => 'book')
-    end
-
-    it "should add a POST (create resource) mock to the network" do
-      Dupe.network.mocks[:post].should be_empty
-      Dupe.define :book
-      Dupe.network.mocks[:post].should_not be_empty
-      Dupe.network.mocks[:post].length.should == 1
-
-      post_mock = Dupe.network.mocks[:post].first
-      post_mock.class.should == Dupe::Network::PostMock
-      post_mock.url_pattern.should == %r{^/books\.xml$}
-      resp, url = post_mock.mocked_response('/books.xml', {:title => "Rooby"})
-      Hash.from_xml(resp).should == Hash.from_xml(Dupe.find(:book).to_xml(:root => 'book'))
-      url.should == "/books/1.xml"
-    end
-
-    it "should add a PUT (update resource) mock to the network" do
-      Dupe.network.mocks[:put].should be_empty
-      book = Dupe.create :book, :title => 'Rooby!'
-      Dupe.network.mocks[:put].should_not be_empty
-      Dupe.network.mocks[:put].length.should == 1
-
-      put_mock = Dupe.network.mocks[:put].first
-      put_mock.class.should == Dupe::Network::PutMock
-      put_mock.url_pattern.should == %r{^/books/(\d+)\.xml$}
-      resp, url = put_mock.mocked_response('/books/1.xml', {:title => "Rails!"})
-      resp.should == nil
-      url.should == "/books/1.xml"
-      book.title.should == "Rails!"
-    end
-
-    it "should add a DELETE mock to the network" do
-      Dupe.network.mocks[:delete].should be_empty
-      book = Dupe.create :book, :title => 'Rooby!'
-      Dupe.network.mocks[:delete].should_not be_empty
-      Dupe.network.mocks[:delete].length.should == 1
-
-      delete_mock = Dupe.network.mocks[:delete].first
-      delete_mock.class.should == Dupe::Network::DeleteMock
-      delete_mock.url_pattern.should == %r{^/books/(\d+)\.xml$}
-    end
-
-    
-    it "should honor ActiveResource site prefix's for the find(:all) and find(<id>) mocks" do
-      Dupe.network.mocks[:get].should be_empty
-      class Author < ActiveResource::Base; self.site='http://somewhere.com/book_services'; end
-      Dupe.create :author
-      Dupe.network.mocks[:get].should_not be_empty
-      Dupe.network.mocks[:get].length.should == 2
-      
-      find_all_mock = Dupe.network.mocks[:get].first
-      find_all_mock.class.should == Dupe::Network::GetMock
-      find_all_mock.url_pattern.should == %r{^/book_services/authors\.xml$}
-      find_all_mock.mocked_response('/book_services/authors.xml').should == Dupe.find(:authors).to_xml(:root => 'authors')
-      
-      find_one_mock = Dupe.network.mocks[:get].last
-      find_one_mock.class.should == Dupe::Network::GetMock
-      find_one_mock.url_pattern.should == %r{^/book_services/authors/(\d+)\.xml$}
-      find_one_mock.mocked_response('/book_services/authors/1.xml').should == Dupe.find(:author).to_xml(:root => 'author')
-    end    
-  end
-  
-  describe "create" do
-    it "should require a model name parameter" do
-      proc {Dupe.create}.should raise_error(ArgumentError)
-      proc {Dupe.create :book}.should_not raise_error(ArgumentError)
-    end
-    
-    it "should create a model if one doesn't already exist" do
-      Dupe.models.should be_empty
-      Dupe.create :book
-      Dupe.models.should_not be_empty
-      Dupe.models[:book].should_not be_nil
-      Dupe.models[:book].name.should == :book
-    end
-    
-    it "should be smart enough to singularize the model name before lookup/create" do
-      Dupe.define :book
-      Dupe.models.should_not be_empty
-      Dupe.models.length.should == 1
-      Dupe.models[:book].should_not be_nil
-      Dupe.create :books
-      Dupe.models.length.should == 1
-      Dupe.models[:books].should be_nil
-      Dupe.models[:book].should_not be_nil
-      Dupe.create :authors
-      Dupe.models.length.should == 2
-      Dupe.models[:author].should_not be_nil
-      Dupe.models[:author].name.should == :author
-      Dupe.models[:authors].should be_nil
-    end
-    
-    it "should create (and return) a database record if passed a single hash" do
-      Dupe.define :book
-      Dupe.database.tables[:book].should be_empty
-      @book = Dupe.create :book, :title => 'test'
-      Dupe.database.tables[:book].should_not be_empty
-      Dupe.database.tables[:book].length.should == 1
-      Dupe.database.tables[:book].first.should == @book
-    end
-    
-    it "should create several records if passed an array of hashes (and return an array of the records created)" do
-      Dupe.define :book
-      Dupe.database.tables[:book].should be_empty
-      @books = Dupe.create :books, [{:title => 'Book 1'}, {:title => 'Book 2'}]
-      Dupe.database.tables[:book].should_not be_empty
-      Dupe.database.tables[:book].length.should == 2
-      Dupe.database.tables[:book].first.should == @books.first
-      Dupe.database.tables[:book].last.should == @books.last      
-    end
-    
-    it "should symbolize hash keys to keep from duplicating column names" do 
-      b = Dupe.create :book, 'title' => 'War And Peace', :title => 'War And Peace'
-      b.title.should == 'War And Peace'
-      b[:title].should == 'War And Peace'
-      b['title'].should == nil
-      
-      bs = Dupe.create :books, [{:test => 2, 'test' => 2}, {:test => 4, 'test' => 4}]
-      bs.first.test.should == 2
-      bs.first[:test].should == 2
-      bs.first['test'].should == nil
-      bs.last.test.should == 4
-      bs.last[:test].should == 4
-      bs.last['test'].should == nil
-    end
-  end
-
-  describe "create resources with unique attributes" do
-    before do
-      Dupe.define :book do |book|
-        book.uniquify :title, :author, :genre
+    describe "using xml" do 
+      before do
+        Dupe.format = ActiveResource::Formats::XmlFormat
       end
-    end
 
-    it "should uniquify the appropriate columns if they don't already have values" do
-      b = Dupe.create :book
-      b.title.should == "book 1 title"
-      b.author.should == "book 1 author"
-      b.genre.should == "book 1 genre"
-
-      b = Dupe.create :book, :title => 'Rooby Rocks', :isbn => 1
-      b.title.should == 'Rooby Rocks'
-      b.author.should == "book 2 author"
-      b.genre.should == "book 2 genre"
-      b.isbn.should == 1
-    end
-  end
-  
-  describe "create resources that have an after_create callback" do
-    before do
-      Dupe.define :book do |book|
-        book.uniquify :title, :author, :genre
-      
-        book.after_create do |b|
-          b.label = b.title.downcase.gsub(/\ +/, '-') unless b.label
-        end
+      it "should add find(:all) and find(<id>) mocks to the network" do
+        Dupe.network.mocks[:get].should be_empty
+        Dupe.create :book
+        Dupe.network.mocks[:get].should_not be_empty
+        Dupe.network.mocks[:get].length.should == 2
+        
+        find_all_mock = Dupe.network.mocks[:get].first
+        find_all_mock.class.should == Dupe::Network::GetMock
+        find_all_mock.url_pattern.should == %r{^/books\.(?:xml|json)$}
+        find_all_mock.mocked_response('/books.xml').should == Dupe.find(:books).to_xml(:root => 'books')
+        
+        find_one_mock = Dupe.network.mocks[:get].last
+        find_one_mock.class.should == Dupe::Network::GetMock
+        find_one_mock.url_pattern.should == %r{^/books/(\d+)\.(?:xml|json)$}
+        find_one_mock.mocked_response('/books/1.xml').should == Dupe.find(:book).to_xml(:root => 'book')
       end
-    end
-    
-    it "should create a label based on the title if a label is passed in during the create call" do
-      b = Dupe.create :book, :title => 'Testing Testing'
-      b.label.should == 'testing-testing'
-      b = Dupe.create :book, :title => 'Testing Testing', :label => 'testbook'
-      b.label.should == 'testbook'
-    end
-  end
-  
-  describe "find" do
-    before do
-      Dupe.define :book
-      @book = Dupe.create :book
-    end
-    
-    it "should require a model name parameter" do
-      proc { Dupe.find }.should raise_error(ArgumentError)
-    end
-    
-    it "should require the model to exist" do
-      proc { Dupe.find :unknown_models }.should raise_error(Dupe::Database::TableDoesNotExistError)
-    end
-    
-    it "should return an array if you ask for a plural model (e.g., Dupe.find :books)" do
-      result = Dupe.find :books
-      result.should be_kind_of(Array)
-      result.should_not be_empty
-      result.length.should == 1
-      result.first.should == @book
-    end
-    
-    it "should return a single record (or nil) if you ask for a singular model (e.g., Dupe.find :book)" do
-      result = Dupe.find :book
-      result.should be_kind_of(Dupe::Database::Record)
-      result.should == @book
-      
-      result = Dupe.find(:book) {|b| false}
-      result.should be_nil
-    end
-  end
-  
-  describe "debug" do
-    it "should default to false" do
-      Dupe.debug.should == false
-    end
-    
-    it "should allow you to set it to true" do
-      Dupe.debug = true
-      Dupe.debug.should == true
-    end
-    
-    it "should persist across a Dupe.reset" do
-      Dupe.debug = true
-      Dupe.debug.should == true
-      Dupe.reset
-      Dupe.debug.should == true
-    end
-  end
-  
-  describe "stub" do
-    it ": when called with only a count and a model_name, it should generate that many blank (id-only) records" do
-      Dupe.database.tables[:author].should be_nil
-      authors = Dupe.stub 20, :authors
-      authors.length.should == 20
-      Dupe.database.tables[:author].length.should == 20
-      authors.collect(&:id).should == (1..20).to_a
-    end
-    
-    it "should accept procs on stubs" do
-      Dupe.database.tables[:author].should be_nil
-      authors = 
-        Dupe.stub(
-          2, 
-          :authors, 
-          :like => {
-            :name => proc {|n| "Author #{n}"},
-            :bio => proc {|n| "Author #{n}'s bio"}
-          }
-        )
-      authors.first.name.should == "Author 1"
-      authors.first.bio.should == "Author 1's bio"
-      authors.last.name.should == "Author 2"
-      authors.last.bio.should == "Author 2's bio"
-      Dupe.database.tables[:author].length.should == 2
-    end
-    
-    it "shouldn't care if the model_name is singular or plural" do
-      Dupe.database.tables.should be_empty
-      Dupe.stub 5, :author
-      Dupe.database.tables.should_not be_empty
-      Dupe.database.tables.length.should == 1
-      Dupe.database.tables[:author].length.should == 5
-      Dupe.stub 5, :authors
-      Dupe.database.tables[:author].length.should == 10
-      Dupe.database.tables.length.should == 1
-    end
-  end
-  
-  describe "find_or_create" do
-    it "should require a model name" do
-      proc { Dupe.find_or_create }.should raise_error(ArgumentError)
-    end
-    
-    it "should find a result if one exists" do
-      b = Dupe.create :book, :title => 'Rooby', :serial_number => 21345
-      found_book = Dupe.find_or_create :book, :title => 'Rooby', :serial_number => 21345
-      b.should === found_book
-      
-      g = Dupe.create :genre, :name => 'Science Fiction', :label => 'sci-fi'
-      found_genre = Dupe.find_or_create :genre, :name => 'Science Fiction', :label => 'sci-fi'
-      g.should === found_genre
-    end
-    
-    it "should create a result if one does not exist" do
-      Dupe.database.tables.should be_empty
-      author = Dupe.find_or_create :author, :name => 'Matt Parker', :age => 27, :label => 'matt-parker'
-      Dupe.database.tables.should_not be_empty
-      author.should === (Dupe.find(:author) {|a| a.label == 'matt-parker' && a.age == 27})
-    end
-    
-    it "should return an array of results if passed a plural model name" do
-      books = Dupe.stub 20, :books, :like => { :title => proc {|n| "book ##{n} title"} }
-      bs = Dupe.find_or_create :books
-      books.should == bs
-    end
-    
-    it "should create and return an array of results if passed a plural model name for which no matching records exist" do
-      Dupe.database.tables.should be_empty
-      books = Dupe.find_or_create :books, :author => 'test'
-      Dupe.database.tables.length.should == 1
-      books.should be_kind_of(Array)
-      books.should == Dupe.find(:books)
-    end
-    
-  end
-  
-  describe "creating resources should not change definitions (regression test)" do
-    before do
-      Dupe.define :book do |book|
-        book.authors []
-        book.genre do
-          Dupe.find_or_create :genre, :name => 'Sci-fi'
-        end
-      end
-    end
-    
-    it "should not add a record to the definition when the default value is an array" do
-      b = Dupe.create :book
-      a = Dupe.create :author
-      b.authors << a
-      b.authors.include?(a).should be_true
-      b2 = Dupe.create :book
-      b2.authors.should be_empty
-    end
-    
-    it "should not dupe the value returned by a lazy attribute" do
-      b = Dupe.create :book
-      b2 = Dupe.create :book
-      b.genre.should == b2.genre
-      b.genre.name = 'Science Fiction'
-      b2.genre.name.should == 'Science Fiction'
-    end
-  end
 
-  describe "##delete" do
-    it "should remove any resources that match the conditions provided in the block" do
-      Dupe.stub 10, :authors
-      Dupe.find(:authors).length.should == 10
-      Dupe.delete :author
-      Dupe.find(:authors).length.should == 9
-      Dupe.delete :authors
-      Dupe.find(:authors).length.should == 0
-      Dupe.create :author, :name => 'CS Lewis'
-      Dupe.create :author, :name => 'Robert Lewis Stevenson'
-      Dupe.create :author, :name => 'Frank Herbert'
-      Dupe.delete(:author) {|a| a.name.match /Lewis/}
-      Dupe.find(:authors).length.should == 1
-      Dupe.find(:authors).first.name.should == 'Frank Herbert'
+      it "should add a POST (create resource) mock to the network" do
+        Dupe.network.mocks[:post].should be_empty
+        Dupe.define :book
+        Dupe.network.mocks[:post].should_not be_empty
+        Dupe.network.mocks[:post].length.should == 1
+
+        post_mock = Dupe.network.mocks[:post].first
+        post_mock.class.should == Dupe::Network::PostMock
+        post_mock.url_pattern.should == %r{^/books\.(?:xml|json)$}
+        resp, url = post_mock.mocked_response('/books.xml', {:title => "Rooby"})
+        Hash.from_xml(resp).should == Hash.from_xml(Dupe.find(:book).to_xml(:root => 'book'))
+        url.should == "/books/1.xml"
+      end
+
+      it "should add a PUT (update resource) mock to the network" do
+        Dupe.network.mocks[:put].should be_empty
+        book = Dupe.create :book, :title => 'Rooby!'
+        Dupe.network.mocks[:put].should_not be_empty
+        Dupe.network.mocks[:put].length.should == 1
+
+        put_mock = Dupe.network.mocks[:put].first
+        put_mock.class.should == Dupe::Network::PutMock
+        put_mock.url_pattern.should == %r{^/books/(\d+)\.(?:xml|json)$}
+        resp, url = put_mock.mocked_response('/books/1.xml', {:title => "Rails!"})
+        resp.should == nil
+        url.should == "/books/1.xml"
+        book.title.should == "Rails!"
+      end
+
+      it "should add a DELETE mock to the network" do
+        Dupe.network.mocks[:delete].should be_empty
+        book = Dupe.create :book, :title => 'Rooby!'
+        Dupe.network.mocks[:delete].should_not be_empty
+        Dupe.network.mocks[:delete].length.should == 1
+
+        delete_mock = Dupe.network.mocks[:delete].first
+        delete_mock.class.should == Dupe::Network::DeleteMock
+        delete_mock.url_pattern.should == %r{^/books/(\d+)\.(?:xml|json)$}
+      end
+
+      
+      it "should honor ActiveResource site prefix's for the find(:all) and find(<id>) mocks" do
+        Dupe.network.mocks[:get].should be_empty
+        class Author < ActiveResource::Base; self.site='http://somewhere.com/book_services'; end
+        Dupe.create :author
+        Dupe.network.mocks[:get].should_not be_empty
+        Dupe.network.mocks[:get].length.should == 2
+        
+        find_all_mock = Dupe.network.mocks[:get].first
+        find_all_mock.class.should == Dupe::Network::GetMock
+        find_all_mock.url_pattern.should == %r{^/book_services/authors\.(?:xml|json)$}
+        find_all_mock.mocked_response('/book_services/authors.xml').should == Dupe.find(:authors).to_xml(:root => 'authors')
+        
+        find_one_mock = Dupe.network.mocks[:get].last
+        find_one_mock.class.should == Dupe::Network::GetMock
+        find_one_mock.url_pattern.should == %r{^/book_services/authors/(\d+)\.(?:xml|json)$}
+        find_one_mock.mocked_response('/book_services/authors/1.xml').should == Dupe.find(:author).to_xml(:root => 'author')
+      end    
+    end
+
+    describe "using json" do
+      before do
+        Dupe.format = ActiveResource::Formats::JsonFormat
+      end
+      
+      it "should add find(:all) and find(<id>) mocks to the network" do
+        Dupe.network.mocks[:get].should be_empty
+        Dupe.create :book
+        Dupe.network.mocks[:get].should_not be_empty
+        Dupe.network.mocks[:get].length.should == 2
+        
+        find_all_mock = Dupe.network.mocks[:get].first
+        find_all_mock.class.should == Dupe::Network::GetMock
+        find_all_mock.url_pattern.should == %r{^/books\.(?:xml|json)$}
+        find_all_mock.mocked_response('/books.json').should == Dupe.find(:books).to_json(:root => 'books')
+        
+        find_one_mock = Dupe.network.mocks[:get].last
+        find_one_mock.class.should == Dupe::Network::GetMock
+        find_one_mock.url_pattern.should == %r{^/books/(\d+)\.(?:xml|json)$}
+        find_one_mock.mocked_response('/books/1.json').should == Dupe.find(:book).to_json(:root => 'book')
+      end
+
+      it "should add a POST (create resource) mock to the network" do
+        Dupe.network.mocks[:post].should be_empty
+        Dupe.define :book
+        Dupe.network.mocks[:post].should_not be_empty
+        Dupe.network.mocks[:post].length.should == 1
+
+        post_mock = Dupe.network.mocks[:post].first
+        post_mock.class.should == Dupe::Network::PostMock
+        post_mock.url_pattern.should == %r{^/books\.(?:xml|json)$}
+        resp, url = post_mock.mocked_response('/books.json', {:title => "Rooby"})
+        Hash.from_json(resp).should == Hash.from_json(Dupe.find(:book).to_json(:root => 'book'))
+        url.should == "/books/1.json"
+      end
+
+      it "should add a PUT (update resource) mock to the network" do
+        Dupe.network.mocks[:put].should be_empty
+        book = Dupe.create :book, :title => 'Rooby!'
+        Dupe.network.mocks[:put].should_not be_empty
+        Dupe.network.mocks[:put].length.should == 1
+
+        put_mock = Dupe.network.mocks[:put].first
+        put_mock.class.should == Dupe::Network::PutMock
+        put_mock.url_pattern.should == %r{^/books/(\d+)\.(?:xml|json)$}
+        resp, url = put_mock.mocked_response('/books/1.json', {:title => "Rails!"})
+        resp.should == nil
+        url.should == "/books/1.json"
+        book.title.should == "Rails!"
+      end
+
+      it "should add a DELETE mock to the network" do
+        Dupe.network.mocks[:delete].should be_empty
+        book = Dupe.create :book, :title => 'Rooby!'
+        Dupe.network.mocks[:delete].should_not be_empty
+        Dupe.network.mocks[:delete].length.should == 1
+
+        delete_mock = Dupe.network.mocks[:delete].first
+        delete_mock.class.should == Dupe::Network::DeleteMock
+        delete_mock.url_pattern.should == %r{^/books/(\d+)\.(?:xml|json)$}
+      end
+
+      
+      it "should honor ActiveResource site prefix's for the find(:all) and find(<id>) mocks" do
+        Dupe.network.mocks[:get].should be_empty
+        class Author < ActiveResource::Base; self.site='http://somewhere.com/book_services'; end
+        Dupe.create :author
+        Dupe.network.mocks[:get].should_not be_empty
+        Dupe.network.mocks[:get].length.should == 2
+        
+        find_all_mock = Dupe.network.mocks[:get].first
+        find_all_mock.class.should == Dupe::Network::GetMock
+        find_all_mock.url_pattern.should == %r{^/book_services/authors\.(?:xml|json)$}
+        find_all_mock.mocked_response('/book_services/authors.json').should == Dupe.find(:authors).to_json(:root => 'authors')
+        
+        find_one_mock = Dupe.network.mocks[:get].last
+        find_one_mock.class.should == Dupe::Network::GetMock
+        find_one_mock.url_pattern.should == %r{^/book_services/authors/(\d+)\.(?:xml|json)$}
+        find_one_mock.mocked_response('/book_services/authors/1.json').should == Dupe.find(:author).to_json(:root => 'author')
+      end    
     end
   end
 end

--- a/spec/lib_specs/mock_definitions_spec.rb
+++ b/spec/lib_specs/mock_definitions_spec.rb
@@ -1,58 +1,119 @@
 require 'spec_helper'
 
 describe "Mock Definition Methods" do
-  before do
-    Dupe.reset
-  end
-  
-  describe "Get" do    
-    it "should require a url pattern that is a regex" do
-      proc { Get() }.should raise_error(ArgumentError)
-      proc { Get 'not a regexp' }.should raise_error(ArgumentError)
-      proc { Get %r{/some_url} }.should_not raise_error
+  describe "using xml" do
+    before do
+      Dupe.format = ActiveResource::Formats::XmlFormat
+      Dupe.reset
     end
     
-    it "should create and return a Dupe::Network::Mock of type :get" do
-      Dupe.network.mocks[:get].should be_empty
-      @book = Dupe.create :book, :label => 'rooby'
-      Dupe.network.mocks[:get].should_not be_empty
-      Dupe.network.mocks[:get].length.should == 2
-      
-      mock = Get %r{/books/([^&]+)\.xml} do |label|
-        Dupe.find(:book) {|b| b.label == label}
+    describe "Get" do    
+      it "should require a url pattern that is a regex" do
+        proc { Get() }.should raise_error(ArgumentError)
+        proc { Get 'not a regexp' }.should raise_error(ArgumentError)
+        proc { Get %r{/some_url} }.should_not raise_error
       end
       
-      Dupe.network.mocks[:get].length.should == 3
-      Dupe.network.mocks[:get].last.should == mock
-      Dupe.network.mocks[:get].last.url_pattern.should == %r{/books/([^&]+)\.xml}
-      book = Dupe.find(:book)
-      Dupe.network.request(:get, '/books/rooby.xml').should == book.to_xml_safe(:root => 'book')
-    end
-  end
-  
-  describe "Post" do    
-    it "should require a url pattern that is a regex" do
-      proc { Post() }.should raise_error(ArgumentError)
-      proc { Post 'not a regexp' }.should raise_error(ArgumentError)
-      proc { Post %r{/some_url} }.should_not raise_error
+      it "should create and return a Dupe::Network::Mock of type :get" do
+        Dupe.network.mocks[:get].should be_empty
+        @book = Dupe.create :book, :label => 'rooby'
+        Dupe.network.mocks[:get].should_not be_empty
+        Dupe.network.mocks[:get].length.should == 2
+        
+        mock = Get %r{/books/([^&]+)\.xml} do |label|
+          Dupe.find(:book) {|b| b.label == label}
+        end
+        
+        Dupe.network.mocks[:get].length.should == 3
+        Dupe.network.mocks[:get].last.should == mock
+        Dupe.network.mocks[:get].last.url_pattern.should == %r{/books/([^&]+)\.xml}
+        book = Dupe.find(:book)
+        Dupe.network.request(:get, '/books/rooby.xml').should == book.make_safe.to_xml(:root => 'book')
+      end
     end
     
-    it "should create and return a Dupe::Network::Mock of type :post" do
-      @book = Dupe.create :book, :label => 'rooby'
-      Dupe.network.mocks[:post].should_not be_empty
-      Dupe.network.mocks[:post].length.should == 1
-      
-      mock = Post %r{/books\.xml} do |post_data|
-        Dupe.create(:book, post_data)
+    describe "Post" do    
+      it "should require a url pattern that is a regex" do
+        proc { Post() }.should raise_error(ArgumentError)
+        proc { Post 'not a regexp' }.should raise_error(ArgumentError)
+        proc { Post %r{/some_url} }.should_not raise_error
       end
       
-      Dupe.network.mocks[:post].length.should == 2
-      Dupe.network.mocks[:post].first.should == mock
-      Dupe.network.mocks[:post].first.url_pattern.should == %r{/books\.xml}
-      book_post = Dupe.create(:book, {:title => "Rooby", :label => "rooby"})
-      book_post.delete(:id)
-      book_response = Dupe.create(:book, {:title => "Rooby", :label => "rooby"})
-      Dupe.network.request(:post, '/books.xml', book_post).should == [Dupe.find(:book) {|b| b.id == 4}.to_xml_safe(:root => 'book'), "/books/4.xml"]
+      it "should create and return a Dupe::Network::Mock of type :post" do
+        @book = Dupe.create :book, :label => 'rooby'
+        Dupe.network.mocks[:post].should_not be_empty
+        Dupe.network.mocks[:post].length.should == 1
+        
+        mock = Post %r{/books\.xml} do |post_data|
+          Dupe.create(:book, post_data)
+        end
+        
+        Dupe.network.mocks[:post].length.should == 2
+        Dupe.network.mocks[:post].first.should == mock
+        Dupe.network.mocks[:post].first.url_pattern.should == %r{/books\.xml}
+        book_post = Dupe.create(:book, {:title => "Rooby", :label => "rooby"})
+        book_post.delete(:id)
+        book_response = Dupe.create(:book, {:title => "Rooby", :label => "rooby"})
+        Dupe.network.request(:post, '/books.xml', book_post).should == [Dupe.find(:book) {|b| b.id == 4}.make_safe.to_xml(:root => 'book'), "/books/4.xml"]
+      end
+    end
+  end
+
+  describe "using json" do
+    before do
+      Dupe.format = ActiveResource::Formats::JsonFormat
+      Dupe.reset
+    end
+    
+    describe "Get" do    
+      it "should require a url pattern that is a regex" do
+        proc { Get() }.should raise_error(ArgumentError)
+        proc { Get 'not a regexp' }.should raise_error(ArgumentError)
+        proc { Get %r{/some_url} }.should_not raise_error
+      end
+      
+      it "should create and return a Dupe::Network::Mock of type :get" do
+        Dupe.network.mocks[:get].should be_empty
+        @book = Dupe.create :book, :label => 'rooby'
+        Dupe.network.mocks[:get].should_not be_empty
+        Dupe.network.mocks[:get].length.should == 2
+        
+        mock = Get %r{/books/([^&]+)\.json} do |label|
+          Dupe.find(:book) {|b| b.label == label}
+        end
+        
+        Dupe.network.mocks[:get].length.should == 3
+        Dupe.network.mocks[:get].last.should == mock
+        Dupe.network.mocks[:get].last.url_pattern.should == %r{/books/([^&]+)\.json}
+        book = Dupe.find(:book)
+        Dupe.network.request(:get, '/books/rooby.json').should == book.make_safe.to_json(:root => 'book')
+      end
+    end
+    
+    describe "Post" do    
+      it "should require a url pattern that is a regex" do
+        proc { Post() }.should raise_error(ArgumentError)
+        proc { Post 'not a regexp' }.should raise_error(ArgumentError)
+        proc { Post %r{/some_url} }.should_not raise_error
+      end
+      
+      it "should create and return a Dupe::Network::Mock of type :post" do
+        @book = Dupe.create :book, :label => 'rooby'
+        Dupe.network.mocks[:post].should_not be_empty
+        Dupe.network.mocks[:post].length.should == 1
+        
+        mock = Post %r{/books\.json} do |post_data|
+          Dupe.create(:book, post_data)
+        end
+        
+        Dupe.network.mocks[:post].length.should == 2
+        Dupe.network.mocks[:post].first.should == mock
+        Dupe.network.mocks[:post].first.url_pattern.should == %r{/books\.json}
+        book_post = Dupe.create(:book, {:title => "Rooby", :label => "rooby"})
+        book_post.delete(:id)
+        book_response = Dupe.create(:book, {:title => "Rooby", :label => "rooby"})
+        Dupe.network.request(:post, '/books.json', book_post).should == [Dupe.find(:book) {|b| b.id == 4}.make_safe.to_json(:root => 'book'), "/books/4.json"]
+      end
     end
   end
 end

--- a/spec/lib_specs/mock_spec.rb
+++ b/spec/lib_specs/mock_spec.rb
@@ -34,160 +34,336 @@ describe Dupe::Network::Mock do
 end
 
 describe Dupe::Network::GetMock do
-  before do
-    Dupe.reset
+  describe "using xml" do
+    before do
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::XmlFormat
+    end
+
+    describe "mocked_response" do
+      describe "on a mock object whose response returns a Dupe.find with actual results" do
+        it "should convert the response result to xml" do
+          url_pattern = %r{/books/(\d+)\.xml}
+          response = proc {|id| Dupe.find(:book) {|b| b.id == id.to_i}}
+          book = Dupe.create :book
+          mock = Dupe::Network::GetMock.new url_pattern, response
+          mock.mocked_response('/books/1.xml').should == book.to_xml(:root => 'book')
+
+          proc { mock.mocked_response('/books/2.xml') }.should raise_error(Dupe::Network::GetMock::ResourceNotFoundError)
+
+          Dupe.define :author
+          mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
+          mock.mocked_response('/authors.xml').should == [].to_xml(:root => 'results')
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          url_pattern = %r{/books/([a-zA-Z0-9-]+)\.xml}
+          response = proc {|label| Dupe.find(:book) {|b| b.label == label}}
+          book = Dupe.create :book, :label => 'rooby'
+          mock = Dupe::Network::GetMock.new url_pattern, response
+          Dupe.network.log.requests.length.should == 0
+          mock.mocked_response('/books/rooby.xml')
+          Dupe.network.log.requests.length.should == 1
+        end
+      end
+
+      describe "on a mock object whose response returns nil" do
+        it "should raise an error" do
+          url_pattern = %r{/authors/(\d+)\.xml}
+          response = proc { |id| Dupe.find(:author) {|a| a.id == id.to_i}}
+          Dupe.define :author
+          mock = Dupe::Network::GetMock.new url_pattern, response
+          proc {mock.mocked_response('/authors/1.xml')}.should raise_error(Dupe::Network::GetMock::ResourceNotFoundError)
+        end
+      end
+
+      describe "on a mock object whose response returns an empty array" do
+        it "should convert the empty array to an xml array record set with root 'results'" do        
+          Dupe.define :author
+          mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
+          mock.mocked_response('/authors.xml').should == [].to_xml(:root => 'results')
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.define :author
+          mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
+          Dupe.network.log.requests.length.should == 0
+          mock.mocked_response('/authors.xml')
+          Dupe.network.log.requests.length.should == 1
+        end
+      end
+
+      describe "on a mock object whose response returns an array of duped records" do
+        it "should convert the array to xml" do        
+          Dupe.create :author  
+          mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
+          mock.mocked_response('/authors.xml').should == Dupe.find(:authors).to_xml(:root => 'authors')
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.create :author
+          mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
+          Dupe.network.log.requests.length.should == 0
+          mock.mocked_response('/authors.xml')
+          Dupe.network.log.requests.length.should == 1
+        end
+      end
+    end
   end
-  
-  describe "mocked_response" do
-    describe "on a mock object whose response returns a Dupe.find with actual results" do
-      it "should convert the response result to xml" do
-        url_pattern = %r{/books/(\d+)\.xml}
-        response = proc {|id| Dupe.find(:book) {|b| b.id == id.to_i}}
-        book = Dupe.create :book
-        mock = Dupe::Network::GetMock.new url_pattern, response
-        mock.mocked_response('/books/1.xml').should == book.to_xml(:root => 'book')
-        
-        proc { mock.mocked_response('/books/2.xml') }.should raise_error(Dupe::Network::GetMock::ResourceNotFoundError)
-        
-        Dupe.define :author
-        mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
-        mock.mocked_response('/authors.xml').should == [].to_xml(:root => 'results')
-      end
-      
-      it "should add a request to the Dupe::Network#log" do
-        url_pattern = %r{/books/([a-zA-Z0-9-]+)\.xml}
-        response = proc {|label| Dupe.find(:book) {|b| b.label == label}}
-        book = Dupe.create :book, :label => 'rooby'
-        mock = Dupe::Network::GetMock.new url_pattern, response
-        Dupe.network.log.requests.length.should == 0
-        mock.mocked_response('/books/rooby.xml')
-        Dupe.network.log.requests.length.should == 1
-      end
+
+  describe "using json" do
+    before do
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::JsonFormat
     end
-    
-    describe "on a mock object whose response returns nil" do
-      it "should raise an error" do
-        url_pattern = %r{/authors/(\d+)\.xml}
-        response = proc { |id| Dupe.find(:author) {|a| a.id == id.to_i}}
-        Dupe.define :author
-        mock = Dupe::Network::GetMock.new url_pattern, response
-        proc {mock.mocked_response('/authors/1.xml')}.should raise_error(Dupe::Network::GetMock::ResourceNotFoundError)
+
+    describe "mocked_response" do
+      describe "on a mock object whose response returns a Dupe.find with actual results" do
+        it "should convert the response result to json" do
+          url_pattern = %r{/books/(\d+)\.json}
+          response = proc {|id| Dupe.find(:book) {|b| b.id == id.to_i}}
+          book = Dupe.create :book
+          mock = Dupe::Network::GetMock.new url_pattern, response
+          mock.mocked_response('/books/1.json').should == book.to_json(:root => 'book')
+
+          proc { mock.mocked_response('/books/2.json') }.should raise_error(Dupe::Network::GetMock::ResourceNotFoundError)
+
+          Dupe.define :author
+          mock = Dupe::Network::GetMock.new %r{/authors\.json$}, proc {Dupe.find :authors}
+          mock.mocked_response('/authors.json').should == [].to_json(:root => 'results')
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          url_pattern = %r{/books/([a-zA-Z0-9-]+)\.json}
+          response = proc {|label| Dupe.find(:book) {|b| b.label == label}}
+          book = Dupe.create :book, :label => 'rooby'
+          mock = Dupe::Network::GetMock.new url_pattern, response
+          Dupe.network.log.requests.length.should == 0
+          mock.mocked_response('/books/rooby.json')
+          Dupe.network.log.requests.length.should == 1
+        end
       end
-    end
-    
-    describe "on a mock object whose response returns an empty array" do
-      it "should convert the empty array to an xml array record set with root 'results'" do        
-        Dupe.define :author
-        mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
-        mock.mocked_response('/authors.xml').should == [].to_xml(:root => 'results')
+
+      describe "on a mock object whose response returns nil" do
+        it "should raise an error" do
+          url_pattern = %r{/authors/(\d+)\.json}
+          response = proc { |id| Dupe.find(:author) {|a| a.id == id.to_i}}
+          Dupe.define :author
+          mock = Dupe::Network::GetMock.new url_pattern, response
+          proc {mock.mocked_response('/authors/1.json')}.should raise_error(Dupe::Network::GetMock::ResourceNotFoundError)
+        end
       end
-      
-      it "should add a request to the Dupe::Network#log" do
-        Dupe.define :author
-        mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
-        Dupe.network.log.requests.length.should == 0
-        mock.mocked_response('/authors.xml')
-        Dupe.network.log.requests.length.should == 1
+
+      describe "on a mock object whose response returns an empty array" do
+        it "should convert the empty array to an json array record set with root 'results'" do        
+          Dupe.define :author
+          mock = Dupe::Network::GetMock.new %r{/authors\.json$}, proc {Dupe.find :authors}
+          mock.mocked_response('/authors.json').should == [].to_json(:root => 'results')
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.define :author
+          mock = Dupe::Network::GetMock.new %r{/authors\.json$}, proc {Dupe.find :authors}
+          Dupe.network.log.requests.length.should == 0
+          mock.mocked_response('/authors.json')
+          Dupe.network.log.requests.length.should == 1
+        end
       end
-    end
-    
-    describe "on a mock object whose response returns an array of duped records" do
-      it "should convert the array to xml" do        
-        Dupe.create :author  
-        mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
-        mock.mocked_response('/authors.xml').should == Dupe.find(:authors).to_xml(:root => 'authors')
-      end
-      
-      it "should add a request to the Dupe::Network#log" do
-        Dupe.create :author
-        mock = Dupe::Network::GetMock.new %r{/authors\.xml$}, proc {Dupe.find :authors}
-        Dupe.network.log.requests.length.should == 0
-        mock.mocked_response('/authors.xml')
-        Dupe.network.log.requests.length.should == 1
+
+      describe "on a mock object whose response returns an array of duped records" do
+        it "should convert the array to json" do        
+          Dupe.create :author  
+          mock = Dupe::Network::GetMock.new %r{/authors\.json$}, proc {Dupe.find :authors}
+          mock.mocked_response('/authors.json').should == Dupe.find(:authors).to_json(:root => 'authors')
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.create :author
+          mock = Dupe::Network::GetMock.new %r{/authors\.json$}, proc {Dupe.find :authors}
+          Dupe.network.log.requests.length.should == 0
+          mock.mocked_response('/authors.json')
+          Dupe.network.log.requests.length.should == 1
+        end
       end
     end
   end
 end
 
 describe Dupe::Network::PostMock do
-  before do
-    Dupe.reset
-  end
-  
-  describe "mocked_response" do
-    describe "on a mock object whose response returns a location of a new record" do
-      it "should convert the new post to xml" do        
-        Dupe.define :author  
-        mock = Dupe::Network::PostMock.new %r{/authors\.xml$}, proc {|post_data| Dupe.create(:author, post_data)}
-        resp, url = mock.mocked_response('/authors.xml', {:name => "Rachel"})
-        resp.should == Dupe.find(:authors).first.to_xml_safe(:root => 'author')
-        url.should == "/authors/1.xml"
+  describe "using xml" do
+    before do
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::XmlFormat
+    end
+
+    describe "mocked_response" do
+      describe "on a mock object whose response returns a location of a new record" do
+        it "should convert the new post to xml" do        
+          Dupe.define :author  
+          mock = Dupe::Network::PostMock.new %r{/authors\.xml$}, proc {|post_data| Dupe.create(:author, post_data)}
+          resp, url = mock.mocked_response('/authors.xml', {:name => "Rachel"})
+          resp.should == Dupe.find(:authors).first.make_safe.to_xml(:root => 'author')
+          url.should == "/authors/1.xml"
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.define :author
+          mock = Dupe::Network::PostMock.new %r{/authors\.xml$}, proc {|post_data| Dupe.create(:author, post_data)}
+          Dupe.network.log.requests.length.should == 0
+          mock.mocked_response('/authors.xml', {:name => "Rachel"})
+          Dupe.network.log.requests.length.should == 1
+        end
       end
-      
-      it "should add a request to the Dupe::Network#log" do
-        Dupe.define :author
-        mock = Dupe::Network::PostMock.new %r{/authors\.xml$}, proc {|post_data| Dupe.create(:author, post_data)}
-        Dupe.network.log.requests.length.should == 0
-        mock.mocked_response('/authors.xml', {:name => "Rachel"})
-        Dupe.network.log.requests.length.should == 1
+    end
+  end
+
+  describe "using json" do
+    before do
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::JsonFormat
+    end
+
+    describe "mocked_response" do
+      describe "on a mock object whose response returns a location of a new record" do
+        it "should convert the new post to json" do        
+          Dupe.define :author  
+          mock = Dupe::Network::PostMock.new %r{/authors\.json$}, proc {|post_data| Dupe.create(:author, post_data)}
+          resp, url = mock.mocked_response('/authors.json', {:name => "Rachel"})
+          resp.should == Dupe.find(:authors).first.make_safe.to_json(:root => 'author')
+          url.should == "/authors/1.json"
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.define :author
+          mock = Dupe::Network::PostMock.new %r{/authors\.json$}, proc {|post_data| Dupe.create(:author, post_data)}
+          Dupe.network.log.requests.length.should == 0
+          mock.mocked_response('/authors.json', {:name => "Rachel"})
+          Dupe.network.log.requests.length.should == 1
+        end
       end
     end
   end
 end
 
 describe Dupe::Network::PutMock do
-  before do
-    Dupe.reset
-  end
-  
-  describe "mocked_response" do
-    describe "on a mock object whose response returns a location of a new record" do
-      before do
-        Dupe.define :author  
-        @a = Dupe.create :author, :name => "Matt"
-        @mock = Dupe::Network::PutMock.new %r{/authors/(\d+)\.xml$}, proc {|id, put_data| Dupe.find(:author) {|a| a.id == id.to_i}.merge!(put_data)}
-      end
+  describe "using xml" do
+    before do
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::XmlFormat
+    end
 
-      it "should convert the put to xml" do        
-        resp, url = @mock.mocked_response('/authors/1.xml', {:name => "Rachel"})
-        resp.should == nil
-        @a.name.should == "Rachel"
-        url.should == "/authors/1.xml"
+    describe "mocked_response" do
+      describe "on a mock object whose response returns a location of a new record" do
+        before do
+          Dupe.define :author  
+          @a = Dupe.create :author, :name => "Matt"
+          @mock = Dupe::Network::PutMock.new %r{/authors/(\d+)\.xml$}, proc {|id, put_data| Dupe.find(:author) {|a| a.id == id.to_i}.merge!(put_data)}
+        end
+
+        it "should convert the put to xml" do        
+          resp, url = @mock.mocked_response('/authors/1.xml', {:name => "Rachel"})
+          resp.should == nil
+          @a.name.should == "Rachel"
+          url.should == "/authors/1.xml"
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.network.log.requests.length.should == 0
+          @mock.mocked_response('/authors/1.xml', {:name => "Rachel"})
+          Dupe.network.log.requests.length.should == 1
+        end
       end
-      
-      it "should add a request to the Dupe::Network#log" do
-        Dupe.network.log.requests.length.should == 0
-        @mock.mocked_response('/authors/1.xml', {:name => "Rachel"})
-        Dupe.network.log.requests.length.should == 1
+    end
+  end
+
+  describe "using json" do
+    before do
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::JsonFormat
+    end
+
+    describe "mocked_response" do
+      describe "on a mock object whose response returns a location of a new record" do
+        before do
+          Dupe.define :author  
+          @a = Dupe.create :author, :name => "Matt"
+          @mock = Dupe::Network::PutMock.new %r{/authors/(\d+)\.json$}, proc {|id, put_data| Dupe.find(:author) {|a| a.id == id.to_i}.merge!(put_data)}
+        end
+
+        it "should convert the put to json" do        
+          resp, url = @mock.mocked_response('/authors/1.json', {:name => "Rachel"})
+          resp.should == nil
+          @a.name.should == "Rachel"
+          url.should == "/authors/1.json"
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.network.log.requests.length.should == 0
+          @mock.mocked_response('/authors/1.json', {:name => "Rachel"})
+          Dupe.network.log.requests.length.should == 1
+        end
       end
     end
   end
 end
 
 describe Dupe::Network::DeleteMock do
-  before do
-    Dupe.reset
-  end
-  
-  describe "mocked_response" do
-    describe "on a mock object whose response returns a location of a new record" do
-      before do
-        Dupe.define :author  
-        @a = Dupe.create :author, :name => "Matt"
-        @mock = Dupe::Network::DeleteMock.new %r{/authors/(\d+)\.xml$}, proc {|id| Dupe.delete(:author) {|a| a.id == id.to_i}}
-      end
+  describe "using xml" do
+    before do
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::XmlFormat
+    end
 
-      it "should convert the put to xml" do        
-        Dupe.find(:authors).length.should == 1
-        resp = @mock.mocked_response('/authors/1.xml')
-        resp.should == nil
-        Dupe.find(:authors).length.should == 0
+    describe "mocked_response" do
+      describe "on a mock object whose response returns a location of a new record" do
+        before do
+          Dupe.define :author  
+          @a = Dupe.create :author, :name => "Matt"
+          @mock = Dupe::Network::DeleteMock.new %r{/authors/(\d+)\.xml$}, proc {|id| Dupe.delete(:author) {|a| a.id == id.to_i}}
+        end
+
+        it "should convert the put to xml" do        
+          Dupe.find(:authors).length.should == 1
+          resp = @mock.mocked_response('/authors/1.xml')
+          resp.should == nil
+          Dupe.find(:authors).length.should == 0
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.network.log.requests.length.should == 0
+          @mock.mocked_response('/authors/1.xml')
+          Dupe.network.log.requests.length.should == 1
+        end
       end
-      
-      it "should add a request to the Dupe::Network#log" do
-        Dupe.network.log.requests.length.should == 0
-        @mock.mocked_response('/authors/1.xml')
-        Dupe.network.log.requests.length.should == 1
+    end
+  end
+
+  describe "using json" do
+    before do
+      Dupe.reset
+      Dupe.format = ActiveResource::Formats::JsonFormat
+    end
+
+    describe "mocked_response" do
+      describe "on a mock object whose response returns a location of a new record" do
+        before do
+          Dupe.define :author  
+          @a = Dupe.create :author, :name => "Matt"
+          @mock = Dupe::Network::DeleteMock.new %r{/authors/(\d+)\.json$}, proc {|id| Dupe.delete(:author) {|a| a.id == id.to_i}}
+        end
+
+        it "should convert the put to json" do        
+          Dupe.find(:authors).length.should == 1
+          resp = @mock.mocked_response('/authors/1.json')
+          resp.should == nil
+          Dupe.find(:authors).length.should == 0
+        end
+
+        it "should add a request to the Dupe::Network#log" do
+          Dupe.network.log.requests.length.should == 0
+          @mock.mocked_response('/authors/1.json')
+          Dupe.network.log.requests.length.should == 1
+        end
       end
     end
   end

--- a/spec/lib_specs/network_spec.rb
+++ b/spec/lib_specs/network_spec.rb
@@ -47,14 +47,38 @@ describe Dupe::Network do
       proc { @network.request(:delete, '/some_url')}.should raise_error(Dupe::Network::RequestNotFoundError)
     end
     
-    it "should return the appropriate mock response if a mock matches the url" do
-      @network.define_service_mock :get, %r{/greeting$}, proc { "hello" }
-      @network.request(:get, '/greeting').should == 'hello'
-      
-      @network.define_service_mock :post, %r{/greeting$}, proc { |post_data| Dupe.create(:greeting, post_data) }
-      resp, url = @network.request(:post, '/greeting', {} )
-      resp.should == Dupe.find(:greeting).to_xml_safe(:root => 'greeting')
-      url.should == "/greetings/1.xml"
+    describe "using xml" do
+      before :each do
+        Dupe.format = ActiveResource::Formats::XmlFormat
+        Dupe.reset
+      end
+
+      it "should return the appropriate mock response if a mock matches the url" do
+        @network.define_service_mock :get, %r{/greeting$}, proc { "hello" }
+        @network.request(:get, '/greeting').should == 'hello'
+        
+        @network.define_service_mock :post, %r{/greeting$}, proc { |post_data| Dupe.create(:greeting, post_data) }
+        resp, url = @network.request(:post, '/greeting', {} )
+        resp.should == Dupe.find(:greeting).make_safe.to_xml(:root => 'greeting')
+        url.should == "/greetings/1.xml"
+      end
+    end
+
+    describe "using json" do
+      before :each do
+        Dupe.format = ActiveResource::Formats::JsonFormat
+        Dupe.reset
+      end
+
+      it "should return the appropriate mock response if a mock matches the url" do
+        @network.define_service_mock :get, %r{/greeting$}, proc { "hello" }
+        @network.request(:get, '/greeting').should == 'hello'
+        
+        @network.define_service_mock :post, %r{/greeting$}, proc { |post_data| Dupe.create(:greeting, post_data) }
+        resp, url = @network.request(:post, '/greeting', {} )
+        resp.should == Dupe.find(:greeting).make_safe.to_json(:root => 'greeting')
+        url.should == "/greetings/1.json"
+      end
     end
   end
   


### PR DESCRIPTION
I've added support for JSON-based resources.  I've wired all the calls to serialize/deserialize/get the mime-type, etc to use the configured formatter (which defaults to the default ActiveResource formatter).

Hopefully this also ensures that Dupe produces JSON and XML that match the JSON/XML produced by the real service (ie, it should respect settings such as 'include_root_in_json')

I think this fixes #23 (it seems to work for me, at least, and the tests pass)
