### PR TITLE
Expand activeresource dependency to work with Rails 4.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,25 +1,25 @@
 PATH
   remote: .
   specs:
-    dupe (1.0.1)
-      activeresource (~> 3.0)
+    dupe (1.1.0.rc1)
+      activeresource (>= 3.0, < 5.0)
 
 GEM
   remote: http://rubygems.org/
   specs:
-    activemodel (3.2.2)
-      activesupport (= 3.2.2)
+    activemodel (3.2.18)
+      activesupport (= 3.2.18)
       builder (~> 3.0.0)
-    activeresource (3.2.2)
-      activemodel (= 3.2.2)
-      activesupport (= 3.2.2)
-    activesupport (3.2.2)
-      i18n (~> 0.6)
+    activeresource (3.2.18)
+      activemodel (= 3.2.18)
+      activesupport (= 3.2.18)
+    activesupport (3.2.18)
+      i18n (~> 0.6, >= 0.6.4)
       multi_json (~> 1.0)
-    builder (3.0.0)
+    builder (3.0.4)
     diff-lcs (1.1.2)
-    i18n (0.6.0)
-    multi_json (1.1.0)
+    i18n (0.6.9)
+    multi_json (1.10.0)
     rspec (2.6.0)
       rspec-core (~> 2.6.0)
       rspec-expectations (~> 2.6.0)

--- a/dupe.gemspec
+++ b/dupe.gemspec
@@ -2,14 +2,14 @@ Gem::Specification.new do |s|
   s.name        = "dupe"
   s.version     = File.read "VERSION"
   s.authors     = "Matt Parker"
-  s.summary     = "Dupe - a testing library for ActiveResource" 
-  s.description = "TDD your services outside in by starting at the client, then working your way back to the server." 
+  s.summary     = "Dupe - a testing library for ActiveResource"
+  s.description = "TDD your services outside in by starting at the client, then working your way back to the server."
   s.email       = "moonmaster9000@gmail.com"
   s.homepage    = "http://github.com/moonmaster9000/dupe"
-  
+
   s.files       = Dir["lib/**/*"]
   s.test_files  = Dir["spec/**/*"]
-  
-  s.add_dependency              "activeresource", "~> 3.0"
+
+  s.add_dependency              "activeresource", ">= 3.0", "< 5.0"
   s.add_development_dependency  "rspec"
 end


### PR DESCRIPTION
A pretty trivial change and it seems to work ok with Rails 4.1.
